### PR TITLE
Convert images to RGB mode before ONNX pipeline

### DIFF
--- a/sd_onnx/sd_onnx.py
+++ b/sd_onnx/sd_onnx.py
@@ -84,12 +84,12 @@ def generate(prompt, prompt_neg, steps, width, height, seed, scale, init_img_pat
         info.add_text('Dream',  f'"{prompt}{neg_prompt_meta_text}" -s {steps} -S {seed} -W {width} -H {height} -C {scale}')
     if opt.mode == "img2img":
         print("img2img", flush=True)
-        img=Image.open(init_img_path)
+        img=Image.open(init_img_path).convert('RGB')
         image=pipe(prompt=prompt, image=img, num_inference_steps=steps, guidance_scale=scale, negative_prompt=prompt_neg, eta=eta, strength=init_strength, generator=rng).images[0]
         info.add_text('Dream',  f'"{prompt}{neg_prompt_meta_text}" -s {steps} -S {seed} -W {width} -H {height} -C {scale} -I {init_img_path} -f {init_strength}')
     if opt.mode == "inpaint":
         print("inpaint", flush=True)
-        img=Image.open(init_img_path)
+        img=Image.open(init_img_path).convert('RGB')
         mask=Image.open(mask_img_path)
         image=pipe(prompt=prompt, image=img, mask_image = mask, height=height, width=width, num_inference_steps=steps, guidance_scale=scale, negative_prompt=prompt_neg, eta=eta, generator=rng).images[0]
         info.add_text('Dream',  f'"{prompt}{neg_prompt_meta_text}" -s {steps} -S {seed} -W {width} -H {height} -C {scale} -I {init_img_path} -f 0.0 -M {mask_img_path}')


### PR DESCRIPTION
This immediate but silent conversion better matches the InvokeAI implementations, based on a quick search of the repo.

The error messages are real nasty otherwise, ranging from a relatively clear hint "ValueError: axes don't match array"—when an 8-bit (mode 'P', color indexed) image is provided—to an indecipherable "The parameter is incorrect" when Diffusers calls into OnnxRuntime with a 32-bit 'RGBA' image. And I imagine HSV and LAB modes would successfully produce garbage.

I suppose this is unnecessary for the "inpaint" mode because that pipeline [already](https://github.com/huggingface/diffusers/blob/946d1cb200a875f694818be37c9c9f7547e9db45/src/diffusers/pipelines/stable_diffusion/pipeline_onnx_stable_diffusion_inpaint.py#L40) does it.